### PR TITLE
Display pomodoroso done

### DIFF
--- a/Taskwarrior Pomodoro/AppDelegate.swift
+++ b/Taskwarrior Pomodoro/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     
     let kPomsLongBreakCharacter = "-"
     let kPomsPomDoneCharacter = "🍅"
+    let kPomsActiveCharacter = "🍊"
 
     
     //MARK: Menu Items Tags -
@@ -275,22 +276,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
     
     func getPomodorosCountTitle() -> String? {
-        guard let log = getTodaysPomodorosLog() else {
-            return nil
+        var title = ""
+        var pomsDone = 0
+        var pomsActive = isActive() ? 1 : 0
+        
+        if let log = getTodaysPomodorosLog() {
+             pomsDone = log["annotations"].count
         }
         
-        let count = log["annotations"].count
-        var title = ""
+        let pomsToDraw = pomsDone + pomsActive
         
-        for i in 0..<count {
+        for i in 0..<pomsToDraw {
             if (i + 1) % pomsPerLongBreak == 1 && i != 0 {
                 title += kPomsLongBreakCharacter
             }
             
-            title += kPomsPomDoneCharacter
+            if pomsDone > 0 {
+                title += kPomsPomDoneCharacter
+                pomsDone -= 1
+            } else if pomsActive > 0 {
+                title += kPomsActiveCharacter
+                pomsActive -= 1
+            }
+            
         }
         
-        return title
+        return title.isEmpty ? nil : title
+    }
+    
+    func isActive() -> Bool {
+        return activeTaskId != nil
     }
     
     

--- a/Taskwarrior Pomodoro/AppDelegate.swift
+++ b/Taskwarrior Pomodoro/AppDelegate.swift
@@ -240,13 +240,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let logFilter = ["status:Completed", kPomodoroLogEntryDescription, "entry:today", "limit:1"]
         let tasks = getTasksUsingFilter(logFilter)
         
-        guard !tasks.isEmpty else {
-            return nil
-        }
-        
-        currentPomodorosLogUUID = tasks[0]["uuid"].string
-        
-        return tasks[0]
+        let task = tasks[safe: 0]
+        currentPomodorosLogUUID = task?["uuid"].string
+        return task
     }
     
     func getTasksUsingFilter(filter: [String]) -> [JSON] {
@@ -602,6 +598,12 @@ extension NSMenuItem {
         
         self.enabled = enabled
         self.tag = tag
+    }
+}
+
+extension Array {
+    subscript (safe index: Int) -> Element? {
+        return (0..<count).contains(index) ? self[index] : nil
     }
 }
 

--- a/Taskwarrior Pomodoro/AppDelegate.swift
+++ b/Taskwarrior Pomodoro/AppDelegate.swift
@@ -267,21 +267,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return taskList;
     }
     
-    func createTodaysPomodorosLogEntry() -> String {
+    func createTodaysPomodorosLogEntry() -> String? {
         let arguments = ["log", kPomodoroLogEntryDescription]
-        let resultString = taskCommandWithResult(arguments)
+        taskCommand(arguments)
         
-        let parts = resultString.characters.split(" ").map(String.init)
-        if parts.count == 3 {
-            let taskId = parts[2].stringByTrimmingCharactersInSet(
-                NSCharacterSet.newlineCharacterSet()
-                ).stringByTrimmingCharactersInSet(
-                    NSCharacterSet.punctuationCharacterSet()
-            )
-            return taskId
-        }
-        
-        return ""
+        let log = getTodaysPomodorosLog()
+        return log?["uuid"].string
     }
     
     func taskCommandWithResult(arguments: [String]) -> String {


### PR DESCRIPTION
## Few things I had to come up with:
### Storing

To keep track of _pomodoros_ done after the app gets restarted I've decided to use _taskwarrior_ to store logs of them.
Each day I log single task. And when a _Pomodoro_ is done, I'm adding a single annotation of that task (with the finished task uuid for some future uses).
### Day break

To display stats for current day, I've decided to ask for the log entry every time 
Additionally I've decided that the finished _pomodoro_ should be counted for the day it started in.
## Changes:
- New menu item
- Writing down and reading finished pomodoros
- A little rework on calling task command (so the code could be easy re-used)
