### PR TITLE
[#13] Sorting - the basic version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,16 @@ pomodoro.defaultFilter=+work
 
 Note that taskwarrior filters can be quite complex (although my specific use of this feature will not be particularly helpful, it may help you come to terms with what is possible by knowing that the one I used for generating the above screenshot was `pomodoro.defaultFilter=(intheamtrellolistid:5591ecedb12a520b50d2e8b8 or intheamtrellolistid:559173de3295c9b2e550243f or intheamtrellolistid:55aee69377ccc07e295462a3) and (-work)`) and are thus outside the scope of this document, but you can [find more information about filters in Taskwarrior's documentation](http://taskwarrior.org/docs/filter.html).
 
+### Task List Sorting
+
+To enable sorting you need to set `pomodoro.default.sort` key.
+
+```
+pomodoro.default.sort=project+,urgency-
+```
+
+To find more, take a look into sorting section in [Taskwarrior's reports documentation](http://taskwarrior.org/docs/report.html).
+
 ### Post-Pomodoro Hook
 
 * [Taskwarrior-Pomodoro-Beeminder](https://github.com/coddingtonbear/taskwarrior-pomodoro-beeminder) provides functionality allowing you to increment Beeminder goals using this "Post-Pomodoro Hook" functionality.


### PR DESCRIPTION
Here's the long awaited sorting.

It takes sorting filter from `pomodoro.default.sort` key which should corespond to sorting standards of Taskwarrior.

Right now it ignores solidus `/` sign (not sure how to use it anyway).
It's not uda aware (_no value_ is lower than _any value_, so in fields like _priority_ results will vary)  
