### PR TITLE
Fix #35 - add configuration options for the sound

### DIFF
--- a/TWMenu/TWMenu.swift
+++ b/TWMenu/TWMenu.swift
@@ -767,6 +767,13 @@ public class TWMenu: NSObject, NSMenuDelegate, NSUserNotificationCenterDelegate 
         notification.informativeText = "You've completed your pomodoro."
         notification.userInfo = ["taskId": taskId!]
         notification.soundName = NSUserNotificationDefaultSoundName
+        if let soundName = configuration!["pomodoro.soundName"] {
+            if soundName == "" {
+                notification.soundName = nil
+            } else {
+                notification.soundName = soundName
+            }
+        }
         notification.hasActionButton = true
         notification.actionButtonTitle = "Start Another"
         

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,24 @@ By default, Taskwarrior Pomodoro uses standard 25-minute (1,500 second) pomodoro
 pomodoro.durationSeconds=2700
 ```
 
+### Pomodoro Sound Name
+
+By default, Taskwarrior Pomodoro uses the default system sound for notifications. This can be overridden by setting ``pomodoro.soundName`` to something in the search path path for sounds.
+
+For example, if you wanted to a bottle sound, set:
+
+```
+pomodoro.soundName=Bottle
+``
+
+To have no sound, set:
+
+```
+pomodoro.soundName=
+```
+
+Note: the API this uses is deprecated, so support is not guaranteed past macOS 11.0.
+
 ### Task project
 
 By default, Taskwarrior Pomodoro do not include project name in task list. If you need tasks to be prefixed by project names, and to customize default separator symbol you could set following setting as follows:


### PR DESCRIPTION
This modifies a deprecated API, but it does work on the latest macOS, so
an upgrade seemed out of scope.

The notification sound worked for me on macOS Catalina, so hopefully
this solves the original problem.


I'm extremely new to Swift, so please let me know if I made any style blunders.